### PR TITLE
Use regular for loop instead of for-in for iterating string characters

### DIFF
--- a/src/does-match.js
+++ b/src/does-match.js
@@ -38,7 +38,7 @@
     }
 
     var replaced = '';
-    for (var i in string) {
+    for (var i = 0, size = string.length; i < size; i++) {
       replaced += replaceDiacritics(string[i]);
     }
 
@@ -101,11 +101,11 @@
       query = query.replace(/ /g, '');
 
       var relevance = 0;
-      for (var i in query) {
+      for (var i = 0, querySize = query.length; i < querySize; i++) {
         var charQuery = query[i];
         var didFindChar = false;
         var isAdjacent = true;
-        for (var j in text) {
+        for (var j = 0, textSize = text.length; j < textSize; j++) {
           var charText = text[j];
           if (charQuery === charText) {
             didFindChar = true;


### PR DESCRIPTION
`for in`  is meant to iterate an object's properties. It is better to be explicit that we want to iterate the string characters. I also cached the array length during the iteration.
