### PR TITLE
Refactoring

### DIFF
--- a/src/does-match.js
+++ b/src/does-match.js
@@ -48,12 +48,12 @@
   var validation = function() {
     var proto = {
       text: function(text) {
-        if (isString(text)) {
+        if (!isString(text)) {
           throw new Error('`text`: expected string');
         }
       },
       query: function(query) {
-        if (isString(query)) {
+        if (!isString(query)) {
           throw new Error('`query`: expected string');
         }
       },
@@ -71,7 +71,7 @@
     };
 
     function isString(src) {
-      return typeof src !== 'string'
+      return typeof src === 'string'
     }
 
     return Object.create(proto);


### PR DESCRIPTION
- `lookahead` method refactored to use a more funcional style
- factory functions created, such as `matching` and `validation`. This way it is easier to use prototypal inheritance in the future, if needed
- helper private funcions added to fatories, such as `isString` and `clearWhitespaces`. I'm not sure if this functions should remain private to the factories using them, but I let it as it was
- programming style preserved

Please, feel free to critique the code and make changes to it.
