### PR TITLE
Fix words match - matching partial words

### DIFF
--- a/test/matches/words.js
+++ b/test/matches/words.js
@@ -55,21 +55,21 @@ describe('words match', function() {
     match('text text the original this is', '<strong>This is the Original Text</strong>');
   });
 
-  // it('should work the same when words are out of order', function() {
-  //   expect(
-  //     doesMatch('Somebody To Love', 'somebody love', {highlightMatches: true}).relevance
-  //   ).to.equal(
-  //     doesMatch('Somebody To Love', 'love somebody', {highlightMatches: true}).relevance
-  //   );
-  // });
-  //
-  // it('should work with partial words', function() {
-  //   var match = function(query, expectedMatch, expectedRelevance) {
-  //     var result = doesMatch('Somebody To Love', query, {highlightMatches: true, minWord: 2});
-  //     expect(result.match).to.equal(expectedMatch);
-  //     expect(result.relevance).to.equal(expectedRelevance);
-  //   };
-  //
-  //   match('love some', '<strong>Some</strong>body To <strong>Love</strong>', 16);
-  // });
+  it('should work the same when words are out of order', function() {
+    expect(
+      doesMatch('Somebody To Love', 'somebody love', {highlightMatches: true}).relevance
+    ).to.equal(
+      doesMatch('Somebody To Love', 'love somebody', {highlightMatches: true}).relevance
+    );
+  });
+
+  it('should work with partial words', function() {
+    var match = function(query, expectedMatch, expectedRelevance) {
+      var result = doesMatch('Somebody To Love', query, {highlightMatches: true, minWord: 2});
+      expect(result.match).to.equal(expectedMatch);
+      expect(result.relevance).to.equal(expectedRelevance);
+    };
+
+    match('love some', '<strong>Some</strong>body To <strong>Love</strong>', 16);
+  });
 });

--- a/test/matches/words.js
+++ b/test/matches/words.js
@@ -54,4 +54,14 @@ describe('words match', function() {
     match('text original the is this', '<strong>This is the Original Text</strong>');
     match('text text the original this is', '<strong>This is the Original Text</strong>');
   });
+
+  it('should return matched query, when highlightMatches is `true`', function() {
+    var match = function(query, expectedMatch) {
+      var result = doesMatch('Somebody To Love', query, {highlightMatches: true, minWord: 2});
+      expect(result.match).to.equal(expectedMatch);
+      expect(result.relevance).to.equal(16);
+    };
+
+    match('love some', '<strong>Some</strong>body To <strong>Love</strong>');
+  });
 });

--- a/test/matches/words.js
+++ b/test/matches/words.js
@@ -55,13 +55,21 @@ describe('words match', function() {
     match('text text the original this is', '<strong>This is the Original Text</strong>');
   });
 
-  it('should return matched query, when highlightMatches is `true`', function() {
-    var match = function(query, expectedMatch) {
-      var result = doesMatch('Somebody To Love', query, {highlightMatches: true, minWord: 2});
-      expect(result.match).to.equal(expectedMatch);
-      expect(result.relevance).to.equal(16);
-    };
-
-    match('love some', '<strong>Some</strong>body To <strong>Love</strong>');
-  });
+  // it('should work the same when words are out of order', function() {
+  //   expect(
+  //     doesMatch('Somebody To Love', 'somebody love', {highlightMatches: true}).relevance
+  //   ).to.equal(
+  //     doesMatch('Somebody To Love', 'love somebody', {highlightMatches: true}).relevance
+  //   );
+  // });
+  //
+  // it('should work with partial words', function() {
+  //   var match = function(query, expectedMatch, expectedRelevance) {
+  //     var result = doesMatch('Somebody To Love', query, {highlightMatches: true, minWord: 2});
+  //     expect(result.match).to.equal(expectedMatch);
+  //     expect(result.relevance).to.equal(expectedRelevance);
+  //   };
+  //
+  //   match('love some', '<strong>Some</strong>body To <strong>Love</strong>', 16);
+  // });
 });


### PR DESCRIPTION
I won't fix this, at least not by now.

This is a proposal of fix, that will make some other tests break because would end up confusing words match with lookahead match.

The point is: I think is interesting have a words match that matches partial words and that matches words out of order, but matching partials words looks a lot like lookahead matching, while matching out of orders is basically the only thing that lookahead doesn't do (like in most text editors' search, that are my primary inspiration of lookahead match).
